### PR TITLE
Pin compatible HF dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Install all required python dependencies:
 pip install -r requirements.txt
 ```
 
+The project expects versions of key libraries that support each other. In particular,
+`sentence-transformers` should be at least version `2.2.2` and
+`huggingface-hub` should be `0.17.0` or newer to avoid import errors when
+running the training scripts.
+
 ## Datasets
 
 Download the dataset from the following repository:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-huggingface-hub>=0.4.0
+huggingface-hub>=0.17.0
 numpy==1.23.2
 openai==0.23.0
 pandas==1.4.3
 rouge==1.0.1
-sentence-transformers==2.2.2
+sentence-transformers>=2.2.2
 transformers==4.30.0
 nltk==3.6.6
 evaluate==0.4.0


### PR DESCRIPTION
## Summary
- ensure `sentence-transformers` and `huggingface-hub` versions are compatible
- document minimum versions of these libraries in the README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689027317e548326a7c1fb4f1d4725e2