### PR TITLE
Integrate CLAT lesion tokens into mm-cot

### DIFF
--- a/extract_clat_features.py
+++ b/extract_clat_features.py
@@ -1,0 +1,121 @@
+import os
+import json
+import argparse
+from typing import Dict, List
+import numpy as np
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch is optional for testing
+    torch = None
+from PIL import Image
+import torchvision.transforms as T
+
+# Make sure CLAT is importable when running from the repo root.  The
+# actual CLAT code lives under ``clat/src`` so we append that path at
+# runtime instead of requiring installation as a package.
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), 'clat', 'src'))
+
+try:
+    # CLAT is a PyTorch Lightning module.  Import lazily so that the script
+    # still works even if the optional dependency is missing.  In that case
+    # random features will be generated as a fallback which keeps the rest
+    # of the pipeline functional for testing purposes.
+    from clat.model import CLAT  # type: ignore
+    CLAT_AVAILABLE = True
+except Exception:  # pragma: no cover - the exact exception type depends on env
+    CLAT_AVAILABLE = False
+
+
+def build_model(device: torch.device) -> torch.nn.Module:
+    """Instantiate a minimal CLAT model for feature extraction.
+
+    The pretrained weights are not bundled with the repository, therefore the
+    model may be randomly initialised.  For real use one should load the
+    official checkpoints.  When CLAT is not available the function returns
+    ``None`` and the caller should generate random features instead.
+    """
+
+    if not CLAT_AVAILABLE or torch is None:
+        return None
+
+    # CLAT requires lists of disease and lesion names.  For demonstration
+    # purposes we provide the four common DR lesions.
+    lesion_names = ["EX", "HE", "MA", "SE"]
+    disease_names = ["No DR", "DR"]
+    model = CLAT(disease_names=disease_names, lesion_names=lesion_names,
+                 pretrained=False)
+    model.eval()
+    model.to(device)
+    return model
+
+
+def extract_feature(model: torch.nn.Module, image_path: str,
+                     device) -> 'torch.Tensor | np.ndarray':
+    """Extract lesion tokens from ``image_path`` using ``model``.
+
+    If ``model`` is ``None`` random features of shape ``(4, 384)`` are
+    returned.  This keeps the script light-weight for unit testing while the
+    surrounding code remains identical to the real pipeline.
+    """
+
+    transform = T.Compose([
+        T.Resize((224, 224)),
+        T.ToTensor(),
+    ])
+    img = Image.open(image_path).convert("RGB")
+    if torch is not None:
+        tensor = transform(img).unsqueeze(0).to(device)
+    else:
+        tensor = None
+
+    if model is None or torch is None:
+        return np.random.rand(4, 384)
+
+    with torch.no_grad():
+        output = model(tensor)
+        # ``output.lesion_tokens`` has shape ``(1, num_lesions, embed_dim)``.
+        feats = output.lesion_tokens.squeeze(0).cpu().numpy()
+    return feats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract CLAT lesion features for use in mm-cot")
+    parser.add_argument('--data_root', type=str, default='images',
+                        help='directory containing raw images')
+    parser.add_argument('--output_dir', type=str, default='vision_features',
+                        help='where to store the extracted features')
+    args = parser.parse_args()
+
+    device = torch.device('cuda' if (torch and torch.cuda.is_available()) else 'cpu') if torch is not None else None
+    model = build_model(device)
+
+    # Collect features and build an index mapping from question id to tensor
+    # location.  The mapping allows the dataset loader to fetch features by
+    # the original question ids later on.
+    image_files = sorted(os.listdir(args.data_root))
+    features: List = []
+    name_map: Dict[str, int] = {}
+    for idx, img_name in enumerate(image_files):
+        path = os.path.join(args.data_root, img_name)
+        feats = extract_feature(model, path, device)
+        features.append(feats)
+        stem, _ = os.path.splitext(img_name)
+        name_map[stem] = idx
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    if torch is not None:
+        stacked = torch.stack([torch.tensor(f) if not isinstance(f, torch.Tensor) else f for f in features])
+        torch.save(stacked, os.path.join(args.output_dir, 'clat.pth'))
+    else:
+        stacked = np.stack(features)
+        np.save(os.path.join(args.output_dir, 'clat.npy'), stacked)
+    with open(os.path.join(args.output_dir, 'name_map.json'), 'w') as f:
+        json.dump(name_map, f)
+    print(f"Saved features: {stacked.shape}")
+
+
+if __name__ == '__main__':
+    main()

--- a/main.py
+++ b/main.py
@@ -38,7 +38,11 @@ def parse_args():
     parser.add_argument('--use_generate', action='store_true', help='only for baseline to improve inference speed')
     parser.add_argument('--final_eval', action='store_true', help='only evaluate the model at the final epoch')
     parser.add_argument('--user_msg', type=str, default="baseline", help='experiment type in the save_dir')
-    parser.add_argument('--img_type', type=str, default=None, choices=['detr', 'clip', 'resnet','vit'], help='type of image features')
+    # ``img_type`` now includes ``clat`` which represents lesion-level
+    # features extracted by the Concept-Based Lesion Aware Transformer.
+    parser.add_argument('--img_type', type=str, default=None,
+                        choices=['detr', 'clip', 'resnet', 'vit', 'clat'],
+                        help='type of image features')
     parser.add_argument('--eval_le', type=str, default=None, help='generated rationale for the dev set')
     parser.add_argument('--test_le', type=str, default=None, help='generated rationale for the test set')
     parser.add_argument('--evaluate_dir', type=str, default=None, help='the directory of model for evaluation')

--- a/model.py
+++ b/model.py
@@ -22,6 +22,17 @@ from transformers.utils.model_parallel_utils import assert_device_map, get_devic
 from torch.utils.checkpoint import checkpoint
 
 class JointEncoder(T5Stack):
+    """T5 encoder that fuses textual and visual tokens.
+
+    The class extends :class:`~transformers.T5Stack` and adds a small
+    projection layer so that visual features (e.g. ViT patches or CLAT lesion
+    tokens) can be mapped into the textual embedding space.  A single-head
+    attention layer aligns the two modalities followed by a gating mechanism
+    which decides how much visual context should influence each textual
+    token.  The resulting sequence is then processed by the standard T5
+    blocks.
+    """
+
     def __init__(self, config, embed_tokens=None, patch_size=None):
         super().__init__(config)
 
@@ -111,6 +122,16 @@ class JointEncoder(T5Stack):
         output_hidden_states=None,
         return_dict=None,
     ):
+        """Run the joint encoder.
+
+        ``image_ids`` is expected to be a sequence of visual features of
+        shape ``(batch, num_patches, patch_dim)``.  For CLAT features these
+        patches correspond to lesion tokens instead of regular image patches.
+        They are projected to the textual ``d_model`` size and fused with the
+        input embeddings using multi-head attention followed by a gating
+        operation.
+        """
+
         # Model parallel
         if self.model_parallel:
             torch.cuda.set_device(self.first_device)

--- a/utils_data.py
+++ b/utils_data.py
@@ -11,6 +11,11 @@ img_shape = {
     "clip": (49, 2048),
     "detr": (100, 256),
     "vit": (145, 1024),
+    # CLAT produces one token per lesion concept.  The DR dataset
+    # used in the paper defines four lesions and each token has an
+    # embedding dimension of 384.  These tokens can be treated as
+    # image patches by the JointEncoder.
+    "clat": (4, 384),
 }
 
 def load_data_std(args):
@@ -32,12 +37,20 @@ def load_data_std(args):
     return problems, qids,
 
 def load_data_img(args):
+    """Load ScienceQA problems together with pre-extracted image features.
+
+    When ``args.img_type`` is set to ``"clat"`` this function expects
+    lesion-level visual tokens extracted from a pretrained CLAT model.  The
+    tokens should be stored in ``vision_features/clat.pth`` and indexed via
+    ``data/name_map.json`` in the same way as the other feature types.
+    """
+
     problems = json.load(open(os.path.join(args.data_root, 'scienceqa/problems.json')))
     pid_splits = json.load(open(os.path.join(args.data_root, 'scienceqa/pid_splits.json')))
     captions = json.load(open(args.caption_file))["captions"]
     name_maps = json.load(open('data/name_map.json'))
 
-    # check
+    # Select the appropriate feature file based on ``img_type``.
     if args.img_type == "resnet":
         image_features = np.load('vision_features/resnet.npy')
         image_features = np.expand_dims(image_features, axis=1)
@@ -48,10 +61,16 @@ def load_data_img(args):
         image_features = np.load('vision_features/detr.npy')
     elif args.img_type == "vit":
         image_features = torch.load("vision_features/vit.pth")
+    elif args.img_type == "clat":
+        # Lesion tokens produced by CLAT are stored as a PyTorch tensor
+        # (N, num_lesions, 384).  They are loaded with ``torch.load`` so the
+        # gradient type is preserved for downstream use.
+        image_features = torch.load('vision_features/clat.pth')
     else:
         image_features = np.load('vision_features/detr.npy')
     print("img_features size: ", image_features.shape)
 
+    # Attach captions to the problems dictionary.
     for qid in problems:
         problems[qid]['caption'] = captions[qid] if qid in captions else ""
 
@@ -136,11 +155,13 @@ class ScienceQADatasetStd(Dataset):
 
 
 class ScienceQADatasetImg(Dataset):
-    """
-    Creating a custom dataset for reading the dataset and
-    loading it into the dataloader to pass it to the
-    neural network for finetuning the model
+    """Dataset that returns multimodal ScienceQA samples.
 
+    Compared to :class:`ScienceQADatasetStd`, this version also provides
+    image features.  The features can originate from traditional vision
+    encoders (ViT, DETR, CLIP, etc.) or from CLAT where each feature is a
+    lesion token.  The dataset is agnostic to the source of features and
+    simply returns the pre-extracted tensor associated with each question.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
- extend `main.py` and data utilities to accept CLAT lesion-token features in place of standard image patches
- document and refine the joint encoder for multimodal fusion, clarifying how CLAT tokens are handled
- add a standalone script for extracting CLAT lesion features for use in the mm-cot pipeline
