### PR TITLE
Handle missing CLAT image features gracefully

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import json
 import argparse
 import random
 from transformers import AutoTokenizer, DataCollatorForSeq2Seq, Seq2SeqTrainingArguments, Seq2SeqTrainer, T5ForConditionalGeneration
+import inspect
 from model import T5ForMultimodalGeneration
 from utils_data import img_shape, load_data_std, load_data_img, ScienceQADatasetStd, ScienceQADatasetImg
 from utils_prompt import *
@@ -217,47 +218,55 @@ def T5Trainer(
         return result
 
     # only use the last model for evaluation to save time
-    if args.final_eval:
-        training_args = Seq2SeqTrainingArguments(
-            save_dir,
-            do_train=True if args.evaluate_dir is None else False,
-            do_eval=False,
-            evaluation_strategy="no",
-            logging_strategy="steps",
-            save_strategy="epoch",
-            save_total_limit = 2,
-            learning_rate= args.lr,
-            eval_accumulation_steps=args.eval_acc,
-            per_device_train_batch_size=args.bs,
-            per_device_eval_batch_size=args.eval_bs,
-            weight_decay=0.01,
-            num_train_epochs=args.epoch,
-            predict_with_generate=args.use_generate,
-            generation_max_length=args.output_len,
-            report_to="none",
-        )
-    # evaluate at each epoch
-    else:
-        training_args = Seq2SeqTrainingArguments(
-            save_dir,
-            do_train=True if args.evaluate_dir is None else False,
-            do_eval=True,
-            evaluation_strategy="epoch",
-            logging_strategy="steps",
-            save_strategy="epoch",
-            save_total_limit = 2,
-            learning_rate= args.lr,
-            eval_accumulation_steps=args.eval_acc,
-            per_device_train_batch_size=args.bs,
-            per_device_eval_batch_size=args.eval_bs,
-            weight_decay=0.01,
-            num_train_epochs=args.epoch,
-            metric_for_best_model="accuracy" if args.prompt_format == "QCMG-A" or args.prompt_format == "QCM-A" else "rougeL",
-            predict_with_generate=args.use_generate,
-            generation_max_length=args.output_len,
-            load_best_model_at_end=True,
-            report_to="none",
-        )
+    common_args = {
+        "output_dir": save_dir,
+        "do_train": True if args.evaluate_dir is None else False,
+        "learning_rate": args.lr,
+        "eval_accumulation_steps": args.eval_acc,
+        "per_device_train_batch_size": args.bs,
+        "per_device_eval_batch_size": args.eval_bs,
+        "weight_decay": 0.01,
+        "num_train_epochs": args.epoch,
+        "predict_with_generate": args.use_generate,
+        "generation_max_length": args.output_len,
+        "report_to": "none",
+    }
+
+    final_eval_args = {
+        "do_eval": False,
+        "evaluation_strategy": "no",
+        "logging_strategy": "steps",
+        "save_strategy": "epoch",
+        "save_total_limit": 2,
+    }
+
+    epoch_eval_args = {
+        "do_eval": True,
+        "evaluation_strategy": "epoch",
+        "logging_strategy": "steps",
+        "save_strategy": "epoch",
+        "save_total_limit": 2,
+        "metric_for_best_model": "accuracy" if args.prompt_format == "QCMG-A" or args.prompt_format == "QCM-A" else "rougeL",
+        "load_best_model_at_end": True,
+    }
+
+    # Filter out kwargs unsupported by the installed transformers version
+    sig = inspect.signature(Seq2SeqTrainingArguments.__init__)
+    valid_params = set(sig.parameters)
+    strategy_args = final_eval_args if args.final_eval else epoch_eval_args
+
+    if "evaluation_strategy" not in valid_params:
+        for k in ["evaluation_strategy", "load_best_model_at_end", "metric_for_best_model"]:
+            strategy_args.pop(k, None)
+
+    for k, v in list(strategy_args.items()):
+        if k not in valid_params:
+            strategy_args.pop(k)
+    for k, v in list(common_args.items()):
+        if k not in valid_params:
+            common_args.pop(k)
+
+    training_args = Seq2SeqTrainingArguments(**{**common_args, **strategy_args})
 
     trainer = Seq2SeqTrainer(
         model=model,

--- a/utils_data.py
+++ b/utils_data.py
@@ -201,8 +201,20 @@ class ScienceQADatasetImg(Dataset):
             self.source_text.append(prompt)
             if str(qid) in name_maps:
                 # ``name_maps`` stores feature indices using a 1-based convention
-                # so convert to zero-based indexing before lookup.
-                i_vectors = image_features[int(name_maps[str(qid)]) - 1]
+                # so convert to zero-based indexing before lookup.  In some
+                # cases the mapping may point to an index that is outside the
+                # available ``image_features`` tensor (e.g. when a feature file
+                # contains fewer images than ``name_maps``).  Guard against
+                # such mismatches by verifying the computed index before
+                # accessing ``image_features``.  If the index is invalid, fall
+                # back to a zero tensor so that training can proceed instead of
+                # raising an ``IndexError``.
+                index = int(name_maps[str(qid)]) - 1
+                if 0 <= index < len(image_features):
+                    i_vectors = image_features[index]
+                else:
+                    shape = img_shape[args.img_type]
+                    i_vectors = np.zeros(shape)
                 self.image_ids.append(i_vectors)
             else:
                 shape = img_shape[args.img_type]


### PR DESCRIPTION
## Summary
- prevent `ScienceQADatasetImg` from crashing when `name_map` points to features missing from `image_features`
- fallback to zeroed image tokens if an index is out of bounds
- dynamically filter `Seq2SeqTrainingArguments` kwargs so training works with older `transformers` versions that lack `evaluation_strategy`
- drop `load_best_model_at_end` and related arguments when `evaluation_strategy` isn't supported, avoiding mismatched-save errors

## Testing
- `pytest -q`
- `python -m py_compile utils_data.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68946f3679e08326a04b4583d56340da